### PR TITLE
Kun deploy til prod hvis bygg er success

### DIFF
--- a/.github/workflows/deploy_prod.yml
+++ b/.github/workflows/deploy_prod.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   deploy:
     name: Deploy to prod-gcp
+    if: ${{ github.event_name == 'repository_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     env:
       DOCKER_IMAGE: docker.pkg.github.com/${{ github.repository }}/${{ github.event.repository.name }}


### PR DESCRIPTION
Deploy til prod trigges i dag selv om `build_image` tryner. Dette er en hack for å ikke kjøre deploy hvis bygget er feilet.