### PR TITLE
Legger til riktig klassenavn for tittel i lenkepaneler

### DIFF
--- a/src/components/SituationPanel.tsx
+++ b/src/components/SituationPanel.tsx
@@ -23,9 +23,9 @@ export const ArticlePanel = (props: { articlePanel: SanityArticlePanel }) => (
                                 className="lenkepanel lenkepanel--border situation-panel__link-panel"
                                 style={{ cursor: 'pointer' }}
                             >
-                                <div>
-                                    <Undertittel tag="p">{article.title}</Undertittel>
-                                </div>
+                                <Undertittel className="lenkepanel__heading" tag="p">
+                                    {article.title}
+                                </Undertittel>
                                 <span className="lenkepanel__indikator" />
                             </a>
                         </Link>


### PR DESCRIPTION
Vi bruker `LenkepanelBase` for å kunne legge på NextJs sin custom routing på lenkene. For at hover-effekten skal bli riktig må vi legge på klassenavn for tittel selv.

![Screenshot 2021-01-15 at 10 48 02](https://user-images.githubusercontent.com/7832273/104709392-2c135800-571f-11eb-90bd-874143aefb26.png)
