### PR TITLE
Halverer CPU og minnebruk

### DIFF
--- a/nais.yaml
+++ b/nais.yaml
@@ -26,11 +26,11 @@ spec:
   webproxy: true
   resources:
     limits:
-      cpu: 1000m
-      memory: 1024Mi
-    requests:
       cpu: 500m
       memory: 512Mi
+    requests:
+      cpu: 200m
+      memory: 256Mi
   vault:
     enabled: false
   accessPolicy:


### PR DESCRIPTION
Halverte CPU- og minnebruk etter oppjusteringen i går, og det ser fortsatt ut til at appen har det fint under oppstart ved deploy til dev-gcp. Før oppjusteringen i går gikk CPU- og minnebruk i taket ved oppstart, som førte til kontinuerlig restart ved deploy.