### PR TITLE
Legger til preview av forside og artikler i Sanity

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,1 @@
 node_modules
-sanity

--- a/sanity/deskStructure.js
+++ b/sanity/deskStructure.js
@@ -1,10 +1,26 @@
 import S from '@sanity/desk-tool/structure-builder';
+import { ArticlePreview } from './preview/ArticlePreview';
+import { FrontpagePreview } from './preview/FrontpagePreview';
 
 export default () =>
     S.list()
         .title('Content')
         .items([
-            S.listItem().title('Frontpage').child(S.editor().schemaType('frontpage').documentId('frontpage')),
+            S.listItem()
+                .title('Frontpage')
+                .child(
+                    S.editor()
+                        .schemaType('frontpage')
+                        .documentId('frontpage')
+                        .views([S.view.form(), S.view.component(FrontpagePreview).title('Preview')])
+                ),
             S.divider(),
             ...S.documentTypeListItems().filter((listItem) => !['frontpage'].includes(listItem.getId())),
         ]);
+
+export const getDefaultDocumentNode = ({ schemaType }) => {
+    switch (schemaType) {
+        case 'article':
+            return S.document().views([S.view.form(), S.view.component(ArticlePreview).title('Preview')]);
+    }
+};

--- a/sanity/preview/ArticlePreview.tsx
+++ b/sanity/preview/ArticlePreview.tsx
@@ -1,0 +1,12 @@
+import * as React from 'react';
+import { WebPreviewWrapper } from './WebPreviewWrapper';
+
+export const ArticlePreview = (ctx: any) => {
+    const slug = ctx.document.displayed?.slug?.current;
+
+    if (!slug) {
+        return <div>Artikkelen må ha en slug (url) før den kan forhåndsvises</div>;
+    }
+
+    return <WebPreviewWrapper url={`/artikkel/${slug}`} />;
+};

--- a/sanity/preview/FrontpagePreview.tsx
+++ b/sanity/preview/FrontpagePreview.tsx
@@ -1,0 +1,6 @@
+import * as React from 'react';
+import { WebPreviewWrapper } from './WebPreviewWrapper';
+
+export const FrontpagePreview = (ctx: any) => {
+    return <WebPreviewWrapper url="/" />;
+};

--- a/sanity/preview/WebPreviewWrapper.tsx
+++ b/sanity/preview/WebPreviewWrapper.tsx
@@ -1,0 +1,30 @@
+import styled from 'styled-components';
+import * as React from 'react';
+
+const Style = styled.div`
+    iframe {
+        height: 100%;
+        width: 100%;
+    }
+    height: calc(100% - 2rem);
+    margin: 1rem;
+    box-shadow: 0 0 1rem #888;
+`;
+
+const getBasepath = () => {
+    if (window.location.href.includes('localhost')) {
+        return 'http://localhost:3000/okonomi-og-gjeld';
+    }
+    if (window.location.href.includes('test')) {
+        return 'https://okonomi-gjeldsradgivning-veiviser.dev.nav.no/okonomi-og-gjeld';
+    }
+    return 'https://www.nav.no/okonomi-og-gjeld';
+};
+
+export function WebPreviewWrapper(props: { url: string }) {
+    return (
+        <Style>
+            <iframe src={`${getBasepath()}/api/preview?slug=${props.url}`} frameBorder={0} />
+        </Style>
+    );
+}

--- a/sanity/tsconfig.json
+++ b/sanity/tsconfig.json
@@ -1,3 +1,6 @@
 {
+  "compilerOptions": {
+      "jsx": "react"
+  },
   "include": ["./node_modules/@sanity/base/types/**/*.ts", "./**/*.ts", "./**/*.tsx"]
 }

--- a/src/pages/api/preview.ts
+++ b/src/pages/api/preview.ts
@@ -1,0 +1,7 @@
+export default function handler(req, res) {
+    if (!req.query.slug) {
+        return res.status(401).json({ message: 'Invalid slug' });
+    }
+    res.setPreviewData({});
+    res.redirect(`/okonomi-og-gjeld/${req.query.slug}`);
+}


### PR DESCRIPTION
Legger til egen preview fane på forsiden og artikkelsidene i Sanity. Fungerer foreløpig bare lokalt, siden Sanity og next-app må kjøre på samme domene (grunnet cookies).

Plan videre er å deploye Sanity sammen med next-appen (under eks /okonomi-og-gjeld/sanity). Da vil preview også fungere i testmiljø og prod.