### PR TITLE
Upgrade next and fix eslint config

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,3 @@
 {
-  "extends": "next/core-web-vitals"
+    "extends": ["next/core-web-vitals"]
 }

--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -1,0 +1,8 @@
+const path = require('path');
+
+const buildEslintCommand = (filenames) =>
+    `next lint --fix --file ${filenames.map((f) => path.relative(process.cwd(), f)).join(' --file ')}`;
+
+module.exports = {
+    '*.{js,jsx,ts,tsx}': [buildEslintCommand],
+};

--- a/next.config.js
+++ b/next.config.js
@@ -38,7 +38,7 @@ const moduleExports = {
     },
 };
 
-if (process.env.ENABLE_SENTRY === "true") {
+if (process.env.ENABLE_SENTRY === 'true') {
     module.exports = withSentryConfig(moduleExports, sentryWebpackPluginOptions);
 } else {
     module.exports = moduleExports;

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
                 "amplitude-js": "^8.8.0",
                 "classnames": "^2.3.1",
                 "html-react-parser": "^1.4.6",
-                "next": "^12.0.9",
+                "next": "^12.0.10",
                 "next-sanity": "^0.4.0",
                 "node-cache": "^5.1.2",
                 "react": "^17.0.2",
@@ -35,10 +35,11 @@
                 "@types/react": "^17.0.38",
                 "@types/react-collapse": "^5.0.1",
                 "@types/styled-components": "^5.1.19",
-                "eslint-config-next": "^12.0.7",
+                "eslint": "^8.8.0",
+                "eslint-config-next": "^12.0.10",
                 "husky": "^7.0.4",
                 "jest": "^27.4.7",
-                "lint-staged": "^12.1.7",
+                "lint-staged": "^12.3.3",
                 "prettier": "^2.5.1",
                 "typescript": "^4.5.4"
             }
@@ -1181,7 +1182,6 @@
             "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.0.5.tgz",
             "integrity": "sha512-BLxsnmK3KyPunz5wmCCpqy0YelEoxxGmH73Is+Z74oOTMtExcjkr3dDR6quwrjh1YspA8DH9gnX1o069KiS9AQ==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "ajv": "^6.12.4",
                 "debug": "^4.3.2",
@@ -1202,7 +1202,6 @@
             "resolved": "https://registry.npmjs.org/globals/-/globals-13.12.0.tgz",
             "integrity": "sha512-uS8X6lSKN2JumVoXrbUz+uG4BYG+eiawqm3qFcT7ammfbUHeCBoJMlHcec/S3krSk73/AE/f0szYFmgAA3kYZg==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "type-fest": "^0.20.2"
             },
@@ -1218,7 +1217,6 @@
             "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
             "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -1231,7 +1229,6 @@
             "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.2.tgz",
             "integrity": "sha512-UXOuFCGcwciWckOpmfKDq/GyhlTf9pN/BzG//x8p8zTOFEcGuA68ANXheFS0AGvy3qgZqLBUkMs7hqzqCKOVwA==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@humanwhocodes/object-schema": "^1.2.1",
                 "debug": "^4.1.1",
@@ -1245,8 +1242,7 @@
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
             "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "node_modules/@istanbuljs/load-nyc-config": {
             "version": "1.1.0",
@@ -2232,23 +2228,23 @@
             }
         },
         "node_modules/@next/env": {
-            "version": "12.0.9",
-            "resolved": "https://registry.npmjs.org/@next/env/-/env-12.0.9.tgz",
-            "integrity": "sha512-oBlkyDop0Stf7MPIzETGv5r0YT/G/weBrknoPOUTaa5qwOeGjuy6gsOVc/SBtrBkOoBmRpD+fFhQJPvmo1mS+g=="
+            "version": "12.0.10",
+            "resolved": "https://registry.npmjs.org/@next/env/-/env-12.0.10.tgz",
+            "integrity": "sha512-mQVj0K6wQ5WEk/sL9SZ+mJXJUaG7el8CpZ6io1uFe9GgNTSC7EgUyNGqM6IQovIFc5ukF4O/hqsdh3S/DCgT2g=="
         },
         "node_modules/@next/eslint-plugin-next": {
-            "version": "12.0.7",
-            "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-12.0.7.tgz",
-            "integrity": "sha512-xk7eMjw4+roWWR/0ETIoToCNs2wdvCGgQUiUO390Rj33/82yxZsh+ODRSaFWkiKp8zHWQN5GCW+U5pfjt/gyQg==",
+            "version": "12.0.10",
+            "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-12.0.10.tgz",
+            "integrity": "sha512-PbGRnV5HGSfRGLjf8uTh1MaWgLwnjKjWiGVjK752ifITJbZ28/5AmLAFT2shDYeux8BHgpgVll5QXu7GN3YLFw==",
             "dev": true,
             "dependencies": {
                 "glob": "7.1.7"
             }
         },
         "node_modules/@next/swc-android-arm64": {
-            "version": "12.0.9",
-            "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-12.0.9.tgz",
-            "integrity": "sha512-aVqgsEn5plmUH2X58sjzhHsH/6majucWTMaaBEs7hHO2+GCwCZc7zaLH4XCBMKPES9Yaja8/pYUbvZQE9DqgFw==",
+            "version": "12.0.10",
+            "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-12.0.10.tgz",
+            "integrity": "sha512-xYwXGkNhzZZsM5MD7KRwF5ZNiC8OLPtVMUiagpPnwENg8Hb0GSQo/NbYWXM8YrawEwp9LaZ7OXiuRKPh2JyBdA==",
             "cpu": [
                 "arm64"
             ],
@@ -2261,9 +2257,9 @@
             }
         },
         "node_modules/@next/swc-darwin-arm64": {
-            "version": "12.0.9",
-            "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.0.9.tgz",
-            "integrity": "sha512-uAgRKm4a2nVdyBiPPJokvmDD1saugOvxljz9ld2ih0CCg5S9vBhqaj3kPGCQBj9hSu3q+Lng2CHnQqG3ga1jzA==",
+            "version": "12.0.10",
+            "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.0.10.tgz",
+            "integrity": "sha512-f2zngulkpIJKWHckhRi7X8GZ+J/tNgFF7lYIh7Qx15JH0OTBsjkqxORlkzy+VZyHJ5sWTCaI6HYYd3ow6qkEEg==",
             "cpu": [
                 "arm64"
             ],
@@ -2276,9 +2272,9 @@
             }
         },
         "node_modules/@next/swc-darwin-x64": {
-            "version": "12.0.9",
-            "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-12.0.9.tgz",
-            "integrity": "sha512-fDOs2lZIyrAdU18IxMA5orBPn9qLbOdu55gXSTNZOhyRJ8ugtbUAejsK7OL0boJy0CCHPAdVRXm01Mwk8tZ9RQ==",
+            "version": "12.0.10",
+            "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-12.0.10.tgz",
+            "integrity": "sha512-Qykcu/gVC5oTvOQoRBhyuS5GYm5SbcgrFTsaLFkGBmEkg9eMQRiaCswk4IafpDXVzITkVFurzSM28q3tLW2qUw==",
             "cpu": [
                 "x64"
             ],
@@ -2291,9 +2287,9 @@
             }
         },
         "node_modules/@next/swc-linux-arm-gnueabihf": {
-            "version": "12.0.9",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.0.9.tgz",
-            "integrity": "sha512-/ni0p9DBvATUML9RQ1ycQuf05uOYKdzA6iI8+eRsARjpGbFVUFbge7XPzlj9g2Q9YWgoN8CSjFGnKRlyky5uHA==",
+            "version": "12.0.10",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.0.10.tgz",
+            "integrity": "sha512-EhqrTFsIXAXN9B/fiiW/QKUK/lSLCXRsLalkUp58KDfMqVLLlj1ORbESAcswiNQOChLuHQSldGEEtOBPQZcd9A==",
             "cpu": [
                 "arm"
             ],
@@ -2306,9 +2302,9 @@
             }
         },
         "node_modules/@next/swc-linux-arm64-gnu": {
-            "version": "12.0.9",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.0.9.tgz",
-            "integrity": "sha512-AphxilJDf95rUxJDHgM9Ww1DaYXZWqTvoKwXeej/0SgSvICcRZrLaFDrkojdXz0Rxr4igX2OdYR1S4/Hj1jWOQ==",
+            "version": "12.0.10",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.0.10.tgz",
+            "integrity": "sha512-kqGtC72g3+JYXZbY2ca6digXR5U6AQ6Dzv4eAxYluMePLHjI/Xye1mf9dwVsgmeXfrD/IRDp5K/3A6UNvBm4oQ==",
             "cpu": [
                 "arm64"
             ],
@@ -2321,9 +2317,9 @@
             }
         },
         "node_modules/@next/swc-linux-arm64-musl": {
-            "version": "12.0.9",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.0.9.tgz",
-            "integrity": "sha512-K5jbvNNzF3mRjWmPdxP5Bg87i7FHivfBj/L0KJlxpkLSC8sffBJDmB6jtMnI7wiPj9J6vmLkbGtSosln78xAlQ==",
+            "version": "12.0.10",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.0.10.tgz",
+            "integrity": "sha512-bG9zTSNwnSgc1Un/7oz1ZVN4UeXsTWrsQhAGWU78lLLCn4Zj9HQoUCRCGLt0OVs2DBZ+WC8CzzFliQ1SKipVbg==",
             "cpu": [
                 "arm64"
             ],
@@ -2336,9 +2332,9 @@
             }
         },
         "node_modules/@next/swc-linux-x64-gnu": {
-            "version": "12.0.9",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.0.9.tgz",
-            "integrity": "sha512-bJZ9bkMkQzsY+UyWezEZ77GWQ4TzwKeXdayX3U3+aEkL8k5C6eKBXlidWdrhu0teLmaUXIyWerWrLnJzwGXdfw==",
+            "version": "12.0.10",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.0.10.tgz",
+            "integrity": "sha512-c79PcfWtyThiYRa1+3KVfDq0zXaI8o1d6dQWNVqDrtLz5HKM/rbjLdvoNuxDwUeZhxI/d9CtyH6GbuKPw5l/5A==",
             "cpu": [
                 "x64"
             ],
@@ -2351,9 +2347,9 @@
             }
         },
         "node_modules/@next/swc-linux-x64-musl": {
-            "version": "12.0.9",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.0.9.tgz",
-            "integrity": "sha512-SR9p0R+v1T32DTXPVAXZw31pmJAkSDotC6Afy+mfC0xrEL3pp95R8sGXYAAUCEPkQp0MEeUOVy2LrToe92X7hQ==",
+            "version": "12.0.10",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.0.10.tgz",
+            "integrity": "sha512-g/scgn+21/MLfizOCZOZt+MxNj2/8Tdlwjvy+QZcSUPZRUI2Y5o3HwBvI1f/bSci+NGRU+bUAO0NFtRJ9MzH5w==",
             "cpu": [
                 "x64"
             ],
@@ -2366,9 +2362,9 @@
             }
         },
         "node_modules/@next/swc-win32-arm64-msvc": {
-            "version": "12.0.9",
-            "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.0.9.tgz",
-            "integrity": "sha512-mzQ1A8vfHhJrvEy5KJZGZWEByXthyKfWofvFaf+oo/5nJl/0Bz1ODP2ajSmbLG++77Eo2AROgbm9pkW1ucvG2A==",
+            "version": "12.0.10",
+            "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.0.10.tgz",
+            "integrity": "sha512-gl6B/ravwMeY5Nv4Il2/ARYJQ6u+KPRwGMjS1ZrNudIKlNn4YBeXh5A4cIVm+dHaff6/O/lGOa5/SUYDMZpkww==",
             "cpu": [
                 "arm64"
             ],
@@ -2381,9 +2377,9 @@
             }
         },
         "node_modules/@next/swc-win32-ia32-msvc": {
-            "version": "12.0.9",
-            "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.0.9.tgz",
-            "integrity": "sha512-MpD2vj1zjo1u3J3wiz3pEKse19Etz+P0GL6XfQkB/9a84vJQ1JWMaWBjmIdivzZv718Il2pRSSx8hymwPfguYQ==",
+            "version": "12.0.10",
+            "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.0.10.tgz",
+            "integrity": "sha512-7RVpZ3tSThC6j+iZB0CUYmFiA3kXmN+pE7QcfyAxFaflKlaZoWNMKHIEZDuxSJc6YmQ6kyxsjqxVay2F5+/YCg==",
             "cpu": [
                 "ia32"
             ],
@@ -2396,9 +2392,9 @@
             }
         },
         "node_modules/@next/swc-win32-x64-msvc": {
-            "version": "12.0.9",
-            "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.0.9.tgz",
-            "integrity": "sha512-1c/sxp/4Qz4F6rCxiYqAnrmghCOFt5hHZ9Kd+rXFW5Mqev4C4XDOUMHdBH55HgnJZqngYhOE0r/XNkCtsIojig==",
+            "version": "12.0.10",
+            "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.0.10.tgz",
+            "integrity": "sha512-oUIWRKd24jFLRWUYO1CZmML5+32BcpVfqhimGaaZIXcOkfQW+iqiAzdqsv688zaGtyKGeB9ZtiK3NDf+Q0v+Vw==",
             "cpu": [
                 "x64"
             ],
@@ -3379,7 +3375,6 @@
             "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
             "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
             "dev": true,
-            "peer": true,
             "peerDependencies": {
                 "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
             }
@@ -3420,7 +3415,6 @@
             "version": "6.12.6",
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
             "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
                 "fast-json-stable-stringify": "^2.0.0",
@@ -3458,6 +3452,7 @@
             "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
             "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
             "dev": true,
+            "optional": true,
             "peer": true,
             "engines": {
                 "node": ">=6"
@@ -3540,8 +3535,7 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
             "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "node_modules/aria-query": {
             "version": "4.2.2",
@@ -4510,7 +4504,6 @@
             "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
             "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "esutils": "^2.0.2"
             },
@@ -4674,6 +4667,7 @@
             "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
             "integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
             "dev": true,
+            "optional": true,
             "peer": true,
             "dependencies": {
                 "ansi-colors": "^4.1.1"
@@ -4843,11 +4837,10 @@
             }
         },
         "node_modules/eslint": {
-            "version": "8.6.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.6.0.tgz",
-            "integrity": "sha512-UvxdOJ7mXFlw7iuHZA4jmzPaUqIw54mZrv+XPYKNbKdLR0et4rf60lIZUU9kiNtnzzMzGWxMV+tQ7uG7JG8DPw==",
+            "version": "8.8.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.8.0.tgz",
+            "integrity": "sha512-H3KXAzQGBH1plhYS3okDix2ZthuYJlQQEGE5k0IKuEqUSiyu4AmxxlJ2MtTYeJ3xB4jDhcYCwGOg2TXYdnDXlQ==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "@eslint/eslintrc": "^1.0.5",
                 "@humanwhocodes/config-array": "^0.9.2",
@@ -4856,11 +4849,10 @@
                 "cross-spawn": "^7.0.2",
                 "debug": "^4.3.2",
                 "doctrine": "^3.0.0",
-                "enquirer": "^2.3.5",
                 "escape-string-regexp": "^4.0.0",
                 "eslint-scope": "^7.1.0",
                 "eslint-utils": "^3.0.0",
-                "eslint-visitor-keys": "^3.1.0",
+                "eslint-visitor-keys": "^3.2.0",
                 "espree": "^9.3.0",
                 "esquery": "^1.4.0",
                 "esutils": "^2.0.2",
@@ -4869,7 +4861,7 @@
                 "functional-red-black-tree": "^1.0.1",
                 "glob-parent": "^6.0.1",
                 "globals": "^13.6.0",
-                "ignore": "^4.0.6",
+                "ignore": "^5.2.0",
                 "import-fresh": "^3.0.0",
                 "imurmurhash": "^0.1.4",
                 "is-glob": "^4.0.0",
@@ -4880,9 +4872,7 @@
                 "minimatch": "^3.0.4",
                 "natural-compare": "^1.4.0",
                 "optionator": "^0.9.1",
-                "progress": "^2.0.0",
                 "regexpp": "^3.2.0",
-                "semver": "^7.2.1",
                 "strip-ansi": "^6.0.1",
                 "strip-json-comments": "^3.1.0",
                 "text-table": "^0.2.0",
@@ -4899,12 +4889,12 @@
             }
         },
         "node_modules/eslint-config-next": {
-            "version": "12.0.7",
-            "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-12.0.7.tgz",
-            "integrity": "sha512-kWOaym5qjyzR190zFKkZMaHetmiRORmzJiKML7Kr9CL213S6SwkrHHCEL58TRdpx0NA+HzrsFR9zgcV2pvV2Yg==",
+            "version": "12.0.10",
+            "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-12.0.10.tgz",
+            "integrity": "sha512-l1er6mwSo1bltjLwmd71p5BdT6k/NQxV1n4lKZI6xt3MDMrq7ChUBr+EecxOry8GC/rCRUtPpH8Ygs0BJc5YLg==",
             "dev": true,
             "dependencies": {
-                "@next/eslint-plugin-next": "12.0.7",
+                "@next/eslint-plugin-next": "12.0.10",
                 "@rushstack/eslint-patch": "^1.0.8",
                 "@typescript-eslint/parser": "^5.0.0",
                 "eslint-import-resolver-node": "^0.3.4",
@@ -5186,7 +5176,6 @@
             "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
             "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "eslint-visitor-keys": "^2.0.0"
             },
@@ -5205,15 +5194,14 @@
             "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
             "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">=10"
             }
         },
         "node_modules/eslint-visitor-keys": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.1.0.tgz",
-            "integrity": "sha512-yWJFpu4DtjsWKkt5GeNBBuZMlNcYVs6vRCLoCVEJrTjaSB6LC98gFipNK/erM2Heg/E8mIK+hXG/pJMLK+eRZA==",
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.2.0.tgz",
+            "integrity": "sha512-IOzT0X126zn7ALX0dwFiUQEdsfzrm4+ISsQS8nukaJXwEyYKRSnEIIDULYg1mCtGp7UUXgfGl7BIolXREQK+XQ==",
             "dev": true,
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -5224,7 +5212,6 @@
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
             "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "color-convert": "^2.0.1"
             },
@@ -5240,7 +5227,6 @@
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
             "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "ansi-styles": "^4.1.0",
                 "supports-color": "^7.1.0"
@@ -5257,7 +5243,6 @@
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
             "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "color-name": "~1.1.4"
             },
@@ -5269,15 +5254,13 @@
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
             "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "node_modules/eslint/node_modules/escape-string-regexp": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
             "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -5290,7 +5273,6 @@
             "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.0.tgz",
             "integrity": "sha512-aWwkhnS0qAXqNOgKOK0dJ2nvzEbhEvpy8OlJ9kZ0FeZnA6zpjv1/Vei+puGFFX7zkPCkHHXb7IDX3A+7yPrRWg==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "esrecurse": "^4.3.0",
                 "estraverse": "^5.2.0"
@@ -5304,7 +5286,6 @@
             "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
             "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">=4.0"
             }
@@ -5314,7 +5295,6 @@
             "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
             "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "is-glob": "^4.0.3"
             },
@@ -5327,7 +5307,6 @@
             "resolved": "https://registry.npmjs.org/globals/-/globals-13.12.0.tgz",
             "integrity": "sha512-uS8X6lSKN2JumVoXrbUz+uG4BYG+eiawqm3qFcT7ammfbUHeCBoJMlHcec/S3krSk73/AE/f0szYFmgAA3kYZg==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "type-fest": "^0.20.2"
             },
@@ -5343,9 +5322,17 @@
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
             "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/eslint/node_modules/ignore": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
+            "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+            "dev": true,
+            "engines": {
+                "node": ">= 4"
             }
         },
         "node_modules/eslint/node_modules/supports-color": {
@@ -5353,7 +5340,6 @@
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
             "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "has-flag": "^4.0.0"
             },
@@ -5366,7 +5352,6 @@
             "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
             "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -5379,7 +5364,6 @@
             "resolved": "https://registry.npmjs.org/espree/-/espree-9.3.0.tgz",
             "integrity": "sha512-d/5nCsb0JcqsSEeQzFZ8DH1RmxPcglRWh24EFTlUEmCKoehXGdpsx0RkHDubqUI8LSAIKMQp4r9SzQ3n+sm4HQ==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "acorn": "^8.7.0",
                 "acorn-jsx": "^5.3.1",
@@ -5394,7 +5378,6 @@
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
             "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
             "dev": true,
-            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -5419,7 +5402,6 @@
             "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
             "integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "estraverse": "^5.1.0"
             },
@@ -5432,7 +5414,6 @@
             "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
             "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">=4.0"
             }
@@ -5441,7 +5422,6 @@
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
             "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
-            "peer": true,
             "dependencies": {
                 "estraverse": "^5.2.0"
             },
@@ -5453,7 +5433,6 @@
             "version": "5.3.0",
             "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
             "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-            "peer": true,
             "engines": {
                 "node": ">=4.0"
             }
@@ -5622,7 +5601,6 @@
             "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
             "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "flat-cache": "^3.0.4"
             },
@@ -5659,7 +5637,6 @@
             "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
             "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "flatted": "^3.1.0",
                 "rimraf": "^3.0.2"
@@ -5672,8 +5649,7 @@
             "version": "3.2.4",
             "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.4.tgz",
             "integrity": "sha512-8/sOawo8tJ4QOBX8YlQBMxL8+RLZfxMQOif9o0KUKTNTjMYElWPE0r/m5VNFxTRd0NSw8qSy8dajrwX4RYI1Hw==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "node_modules/follow-redirects": {
             "version": "1.14.7",
@@ -5751,8 +5727,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
             "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "node_modules/gauge": {
             "version": "2.7.4",
@@ -6224,7 +6199,6 @@
             "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
             "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">= 4"
             }
@@ -6239,7 +6213,6 @@
             "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
             "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "parent-module": "^1.0.0",
                 "resolve-from": "^4.0.0"
@@ -8355,7 +8328,6 @@
             "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
             "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "argparse": "^2.0.1"
             },
@@ -8471,15 +8443,13 @@
         "node_modules/json-schema-traverse": {
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-            "peer": true
+            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
         },
         "node_modules/json-stable-stringify-without-jsonify": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
             "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "node_modules/json5": {
             "version": "2.2.0",
@@ -8629,7 +8599,6 @@
             "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
             "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "prelude-ls": "^1.2.1",
                 "type-check": "~0.4.0"
@@ -8656,9 +8625,9 @@
             }
         },
         "node_modules/lint-staged": {
-            "version": "12.1.7",
-            "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-12.1.7.tgz",
-            "integrity": "sha512-bltv/ejiLWtowExpjU+s5z8j1Byjg9AlmaAjMmqNbIicY69u6sYIwXGg0dCn0TlkrrY2CphtHIXAkbZ+1VoWQQ==",
+            "version": "12.3.3",
+            "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-12.3.3.tgz",
+            "integrity": "sha512-OqcLsqcPOqzvsfkxjeBpZylgJ3SRG1RYqc9LxC6tkt6tNsq1bNVkAixBwX09f6CobcHswzqVOCBpFR1Fck0+ag==",
             "dev": true,
             "dependencies": {
                 "cli-truncate": "^3.1.0",
@@ -8667,10 +8636,10 @@
                 "debug": "^4.3.3",
                 "execa": "^5.1.1",
                 "lilconfig": "2.0.4",
-                "listr2": "^3.13.5",
+                "listr2": "^4.0.1",
                 "micromatch": "^4.0.4",
                 "normalize-path": "^3.0.0",
-                "object-inspect": "^1.11.1",
+                "object-inspect": "^1.12.0",
                 "string-argv": "^0.3.1",
                 "supports-color": "^9.2.1",
                 "yaml": "^1.10.2"
@@ -8704,9 +8673,9 @@
             }
         },
         "node_modules/listr2": {
-            "version": "3.14.0",
-            "resolved": "https://registry.npmjs.org/listr2/-/listr2-3.14.0.tgz",
-            "integrity": "sha512-TyWI8G99GX9GjE54cJ+RrNMcIFBfwMPxc3XTFiAYGN4s10hWROGtOg7+O6u6LE3mNkyld7RSLE6nrKBvTfcs3g==",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/listr2/-/listr2-4.0.2.tgz",
+            "integrity": "sha512-YcgwfCWpvPbj9FLUGqvdFvd3hrFWKpOeuXznRgfWEJ7RNr8b/IKKIKZABHx3aU+4CWN/iSAFFSReziQG6vTeIA==",
             "dev": true,
             "dependencies": {
                 "cli-truncate": "^2.1.0",
@@ -8714,12 +8683,12 @@
                 "log-update": "^4.0.0",
                 "p-map": "^4.0.0",
                 "rfdc": "^1.3.0",
-                "rxjs": "^7.5.1",
+                "rxjs": "^7.5.2",
                 "through": "^2.3.8",
                 "wrap-ansi": "^7.0.0"
             },
             "engines": {
-                "node": ">=10.0.0"
+                "node": ">=12"
             },
             "peerDependencies": {
                 "enquirer": ">= 2.3.0 < 3"
@@ -8853,8 +8822,7 @@
             "version": "4.6.2",
             "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
             "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "node_modules/log-update": {
             "version": "4.0.0",
@@ -9142,11 +9110,11 @@
             "peer": true
         },
         "node_modules/next": {
-            "version": "12.0.9",
-            "resolved": "https://registry.npmjs.org/next/-/next-12.0.9.tgz",
-            "integrity": "sha512-omfYqoR/DvbdOIJ6SS1unKJ4mGIxUPs0RPa7wr/Mft22OCKgJhuG+aI9KFYi5ZJBwoFQk1vqaMKpWz5qr+dN0Q==",
+            "version": "12.0.10",
+            "resolved": "https://registry.npmjs.org/next/-/next-12.0.10.tgz",
+            "integrity": "sha512-1y3PpGzpb/EZzz1jgne+JfZXKAVJUjYXwxzrADf/LWN+8yi9o79vMLXpW3mevvCHkEF2sBnIdjzNn16TJrINUw==",
             "dependencies": {
-                "@next/env": "12.0.9",
+                "@next/env": "12.0.10",
                 "caniuse-lite": "^1.0.30001283",
                 "postcss": "8.4.5",
                 "styled-jsx": "5.0.0",
@@ -9159,17 +9127,17 @@
                 "node": ">=12.22.0"
             },
             "optionalDependencies": {
-                "@next/swc-android-arm64": "12.0.9",
-                "@next/swc-darwin-arm64": "12.0.9",
-                "@next/swc-darwin-x64": "12.0.9",
-                "@next/swc-linux-arm-gnueabihf": "12.0.9",
-                "@next/swc-linux-arm64-gnu": "12.0.9",
-                "@next/swc-linux-arm64-musl": "12.0.9",
-                "@next/swc-linux-x64-gnu": "12.0.9",
-                "@next/swc-linux-x64-musl": "12.0.9",
-                "@next/swc-win32-arm64-msvc": "12.0.9",
-                "@next/swc-win32-ia32-msvc": "12.0.9",
-                "@next/swc-win32-x64-msvc": "12.0.9"
+                "@next/swc-android-arm64": "12.0.10",
+                "@next/swc-darwin-arm64": "12.0.10",
+                "@next/swc-darwin-x64": "12.0.10",
+                "@next/swc-linux-arm-gnueabihf": "12.0.10",
+                "@next/swc-linux-arm64-gnu": "12.0.10",
+                "@next/swc-linux-arm64-musl": "12.0.10",
+                "@next/swc-linux-x64-gnu": "12.0.10",
+                "@next/swc-linux-x64-musl": "12.0.10",
+                "@next/swc-win32-arm64-msvc": "12.0.10",
+                "@next/swc-win32-ia32-msvc": "12.0.10",
+                "@next/swc-win32-x64-msvc": "12.0.10"
             },
             "peerDependencies": {
                 "fibers": ">= 3.1.0",
@@ -9428,7 +9396,6 @@
             "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
             "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "deep-is": "^0.1.3",
                 "fast-levenshtein": "^2.0.6",
@@ -9510,7 +9477,6 @@
             "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
             "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "callsites": "^3.0.0"
             },
@@ -9710,7 +9676,6 @@
             "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
             "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">= 0.8.0"
             }
@@ -10030,7 +9995,6 @@
             "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
             "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">=8"
             },
@@ -10091,7 +10055,6 @@
             "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
             "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">=4"
             }
@@ -10641,7 +10604,6 @@
             "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
             "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
             "dev": true,
-            "peer": true,
             "engines": {
                 "node": ">=8"
             },
@@ -10931,8 +10893,7 @@
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
             "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "node_modules/throat": {
             "version": "6.0.1",
@@ -11081,7 +11042,6 @@
             "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
             "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
             "dev": true,
-            "peer": true,
             "dependencies": {
                 "prelude-ls": "^1.2.1"
             },
@@ -11156,7 +11116,6 @@
             "version": "4.4.1",
             "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
             "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-            "peer": true,
             "dependencies": {
                 "punycode": "^2.1.0"
             }
@@ -11215,8 +11174,7 @@
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
             "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "node_modules/v8-to-istanbul": {
             "version": "8.1.1",
@@ -12502,7 +12460,6 @@
             "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.0.5.tgz",
             "integrity": "sha512-BLxsnmK3KyPunz5wmCCpqy0YelEoxxGmH73Is+Z74oOTMtExcjkr3dDR6quwrjh1YspA8DH9gnX1o069KiS9AQ==",
             "dev": true,
-            "peer": true,
             "requires": {
                 "ajv": "^6.12.4",
                 "debug": "^4.3.2",
@@ -12520,7 +12477,6 @@
                     "resolved": "https://registry.npmjs.org/globals/-/globals-13.12.0.tgz",
                     "integrity": "sha512-uS8X6lSKN2JumVoXrbUz+uG4BYG+eiawqm3qFcT7ammfbUHeCBoJMlHcec/S3krSk73/AE/f0szYFmgAA3kYZg==",
                     "dev": true,
-                    "peer": true,
                     "requires": {
                         "type-fest": "^0.20.2"
                     }
@@ -12529,8 +12485,7 @@
                     "version": "0.20.2",
                     "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
                     "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-                    "dev": true,
-                    "peer": true
+                    "dev": true
                 }
             }
         },
@@ -12539,7 +12494,6 @@
             "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.2.tgz",
             "integrity": "sha512-UXOuFCGcwciWckOpmfKDq/GyhlTf9pN/BzG//x8p8zTOFEcGuA68ANXheFS0AGvy3qgZqLBUkMs7hqzqCKOVwA==",
             "dev": true,
-            "peer": true,
             "requires": {
                 "@humanwhocodes/object-schema": "^1.2.1",
                 "debug": "^4.1.1",
@@ -12550,8 +12504,7 @@
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
             "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "@istanbuljs/load-nyc-config": {
             "version": "1.1.0",
@@ -13272,83 +13225,83 @@
             }
         },
         "@next/env": {
-            "version": "12.0.9",
-            "resolved": "https://registry.npmjs.org/@next/env/-/env-12.0.9.tgz",
-            "integrity": "sha512-oBlkyDop0Stf7MPIzETGv5r0YT/G/weBrknoPOUTaa5qwOeGjuy6gsOVc/SBtrBkOoBmRpD+fFhQJPvmo1mS+g=="
+            "version": "12.0.10",
+            "resolved": "https://registry.npmjs.org/@next/env/-/env-12.0.10.tgz",
+            "integrity": "sha512-mQVj0K6wQ5WEk/sL9SZ+mJXJUaG7el8CpZ6io1uFe9GgNTSC7EgUyNGqM6IQovIFc5ukF4O/hqsdh3S/DCgT2g=="
         },
         "@next/eslint-plugin-next": {
-            "version": "12.0.7",
-            "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-12.0.7.tgz",
-            "integrity": "sha512-xk7eMjw4+roWWR/0ETIoToCNs2wdvCGgQUiUO390Rj33/82yxZsh+ODRSaFWkiKp8zHWQN5GCW+U5pfjt/gyQg==",
+            "version": "12.0.10",
+            "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-12.0.10.tgz",
+            "integrity": "sha512-PbGRnV5HGSfRGLjf8uTh1MaWgLwnjKjWiGVjK752ifITJbZ28/5AmLAFT2shDYeux8BHgpgVll5QXu7GN3YLFw==",
             "dev": true,
             "requires": {
                 "glob": "7.1.7"
             }
         },
         "@next/swc-android-arm64": {
-            "version": "12.0.9",
-            "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-12.0.9.tgz",
-            "integrity": "sha512-aVqgsEn5plmUH2X58sjzhHsH/6majucWTMaaBEs7hHO2+GCwCZc7zaLH4XCBMKPES9Yaja8/pYUbvZQE9DqgFw==",
+            "version": "12.0.10",
+            "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-12.0.10.tgz",
+            "integrity": "sha512-xYwXGkNhzZZsM5MD7KRwF5ZNiC8OLPtVMUiagpPnwENg8Hb0GSQo/NbYWXM8YrawEwp9LaZ7OXiuRKPh2JyBdA==",
             "optional": true
         },
         "@next/swc-darwin-arm64": {
-            "version": "12.0.9",
-            "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.0.9.tgz",
-            "integrity": "sha512-uAgRKm4a2nVdyBiPPJokvmDD1saugOvxljz9ld2ih0CCg5S9vBhqaj3kPGCQBj9hSu3q+Lng2CHnQqG3ga1jzA==",
+            "version": "12.0.10",
+            "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.0.10.tgz",
+            "integrity": "sha512-f2zngulkpIJKWHckhRi7X8GZ+J/tNgFF7lYIh7Qx15JH0OTBsjkqxORlkzy+VZyHJ5sWTCaI6HYYd3ow6qkEEg==",
             "optional": true
         },
         "@next/swc-darwin-x64": {
-            "version": "12.0.9",
-            "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-12.0.9.tgz",
-            "integrity": "sha512-fDOs2lZIyrAdU18IxMA5orBPn9qLbOdu55gXSTNZOhyRJ8ugtbUAejsK7OL0boJy0CCHPAdVRXm01Mwk8tZ9RQ==",
+            "version": "12.0.10",
+            "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-12.0.10.tgz",
+            "integrity": "sha512-Qykcu/gVC5oTvOQoRBhyuS5GYm5SbcgrFTsaLFkGBmEkg9eMQRiaCswk4IafpDXVzITkVFurzSM28q3tLW2qUw==",
             "optional": true
         },
         "@next/swc-linux-arm-gnueabihf": {
-            "version": "12.0.9",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.0.9.tgz",
-            "integrity": "sha512-/ni0p9DBvATUML9RQ1ycQuf05uOYKdzA6iI8+eRsARjpGbFVUFbge7XPzlj9g2Q9YWgoN8CSjFGnKRlyky5uHA==",
+            "version": "12.0.10",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.0.10.tgz",
+            "integrity": "sha512-EhqrTFsIXAXN9B/fiiW/QKUK/lSLCXRsLalkUp58KDfMqVLLlj1ORbESAcswiNQOChLuHQSldGEEtOBPQZcd9A==",
             "optional": true
         },
         "@next/swc-linux-arm64-gnu": {
-            "version": "12.0.9",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.0.9.tgz",
-            "integrity": "sha512-AphxilJDf95rUxJDHgM9Ww1DaYXZWqTvoKwXeej/0SgSvICcRZrLaFDrkojdXz0Rxr4igX2OdYR1S4/Hj1jWOQ==",
+            "version": "12.0.10",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.0.10.tgz",
+            "integrity": "sha512-kqGtC72g3+JYXZbY2ca6digXR5U6AQ6Dzv4eAxYluMePLHjI/Xye1mf9dwVsgmeXfrD/IRDp5K/3A6UNvBm4oQ==",
             "optional": true
         },
         "@next/swc-linux-arm64-musl": {
-            "version": "12.0.9",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.0.9.tgz",
-            "integrity": "sha512-K5jbvNNzF3mRjWmPdxP5Bg87i7FHivfBj/L0KJlxpkLSC8sffBJDmB6jtMnI7wiPj9J6vmLkbGtSosln78xAlQ==",
+            "version": "12.0.10",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.0.10.tgz",
+            "integrity": "sha512-bG9zTSNwnSgc1Un/7oz1ZVN4UeXsTWrsQhAGWU78lLLCn4Zj9HQoUCRCGLt0OVs2DBZ+WC8CzzFliQ1SKipVbg==",
             "optional": true
         },
         "@next/swc-linux-x64-gnu": {
-            "version": "12.0.9",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.0.9.tgz",
-            "integrity": "sha512-bJZ9bkMkQzsY+UyWezEZ77GWQ4TzwKeXdayX3U3+aEkL8k5C6eKBXlidWdrhu0teLmaUXIyWerWrLnJzwGXdfw==",
+            "version": "12.0.10",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.0.10.tgz",
+            "integrity": "sha512-c79PcfWtyThiYRa1+3KVfDq0zXaI8o1d6dQWNVqDrtLz5HKM/rbjLdvoNuxDwUeZhxI/d9CtyH6GbuKPw5l/5A==",
             "optional": true
         },
         "@next/swc-linux-x64-musl": {
-            "version": "12.0.9",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.0.9.tgz",
-            "integrity": "sha512-SR9p0R+v1T32DTXPVAXZw31pmJAkSDotC6Afy+mfC0xrEL3pp95R8sGXYAAUCEPkQp0MEeUOVy2LrToe92X7hQ==",
+            "version": "12.0.10",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.0.10.tgz",
+            "integrity": "sha512-g/scgn+21/MLfizOCZOZt+MxNj2/8Tdlwjvy+QZcSUPZRUI2Y5o3HwBvI1f/bSci+NGRU+bUAO0NFtRJ9MzH5w==",
             "optional": true
         },
         "@next/swc-win32-arm64-msvc": {
-            "version": "12.0.9",
-            "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.0.9.tgz",
-            "integrity": "sha512-mzQ1A8vfHhJrvEy5KJZGZWEByXthyKfWofvFaf+oo/5nJl/0Bz1ODP2ajSmbLG++77Eo2AROgbm9pkW1ucvG2A==",
+            "version": "12.0.10",
+            "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.0.10.tgz",
+            "integrity": "sha512-gl6B/ravwMeY5Nv4Il2/ARYJQ6u+KPRwGMjS1ZrNudIKlNn4YBeXh5A4cIVm+dHaff6/O/lGOa5/SUYDMZpkww==",
             "optional": true
         },
         "@next/swc-win32-ia32-msvc": {
-            "version": "12.0.9",
-            "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.0.9.tgz",
-            "integrity": "sha512-MpD2vj1zjo1u3J3wiz3pEKse19Etz+P0GL6XfQkB/9a84vJQ1JWMaWBjmIdivzZv718Il2pRSSx8hymwPfguYQ==",
+            "version": "12.0.10",
+            "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.0.10.tgz",
+            "integrity": "sha512-7RVpZ3tSThC6j+iZB0CUYmFiA3kXmN+pE7QcfyAxFaflKlaZoWNMKHIEZDuxSJc6YmQ6kyxsjqxVay2F5+/YCg==",
             "optional": true
         },
         "@next/swc-win32-x64-msvc": {
-            "version": "12.0.9",
-            "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.0.9.tgz",
-            "integrity": "sha512-1c/sxp/4Qz4F6rCxiYqAnrmghCOFt5hHZ9Kd+rXFW5Mqev4C4XDOUMHdBH55HgnJZqngYhOE0r/XNkCtsIojig==",
+            "version": "12.0.10",
+            "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.0.10.tgz",
+            "integrity": "sha512-oUIWRKd24jFLRWUYO1CZmML5+32BcpVfqhimGaaZIXcOkfQW+iqiAzdqsv688zaGtyKGeB9ZtiK3NDf+Q0v+Vw==",
             "optional": true
         },
         "@nodelib/fs.scandir": {
@@ -14187,7 +14140,6 @@
             "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
             "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
             "dev": true,
-            "peer": true,
             "requires": {}
         },
         "acorn-walk": {
@@ -14217,7 +14169,6 @@
             "version": "6.12.6",
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
             "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-            "peer": true,
             "requires": {
                 "fast-deep-equal": "^3.1.1",
                 "fast-json-stable-stringify": "^2.0.0",
@@ -14249,6 +14200,7 @@
             "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
             "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
             "dev": true,
+            "optional": true,
             "peer": true
         },
         "ansi-escapes": {
@@ -14309,8 +14261,7 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
             "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "aria-query": {
             "version": "4.2.2",
@@ -15055,7 +15006,6 @@
             "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
             "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
             "dev": true,
-            "peer": true,
             "requires": {
                 "esutils": "^2.0.2"
             }
@@ -15183,6 +15133,7 @@
             "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
             "integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
             "dev": true,
+            "optional": true,
             "peer": true,
             "requires": {
                 "ansi-colors": "^4.1.1"
@@ -15303,11 +15254,10 @@
             }
         },
         "eslint": {
-            "version": "8.6.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.6.0.tgz",
-            "integrity": "sha512-UvxdOJ7mXFlw7iuHZA4jmzPaUqIw54mZrv+XPYKNbKdLR0et4rf60lIZUU9kiNtnzzMzGWxMV+tQ7uG7JG8DPw==",
+            "version": "8.8.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.8.0.tgz",
+            "integrity": "sha512-H3KXAzQGBH1plhYS3okDix2ZthuYJlQQEGE5k0IKuEqUSiyu4AmxxlJ2MtTYeJ3xB4jDhcYCwGOg2TXYdnDXlQ==",
             "dev": true,
-            "peer": true,
             "requires": {
                 "@eslint/eslintrc": "^1.0.5",
                 "@humanwhocodes/config-array": "^0.9.2",
@@ -15316,11 +15266,10 @@
                 "cross-spawn": "^7.0.2",
                 "debug": "^4.3.2",
                 "doctrine": "^3.0.0",
-                "enquirer": "^2.3.5",
                 "escape-string-regexp": "^4.0.0",
                 "eslint-scope": "^7.1.0",
                 "eslint-utils": "^3.0.0",
-                "eslint-visitor-keys": "^3.1.0",
+                "eslint-visitor-keys": "^3.2.0",
                 "espree": "^9.3.0",
                 "esquery": "^1.4.0",
                 "esutils": "^2.0.2",
@@ -15329,7 +15278,7 @@
                 "functional-red-black-tree": "^1.0.1",
                 "glob-parent": "^6.0.1",
                 "globals": "^13.6.0",
-                "ignore": "^4.0.6",
+                "ignore": "^5.2.0",
                 "import-fresh": "^3.0.0",
                 "imurmurhash": "^0.1.4",
                 "is-glob": "^4.0.0",
@@ -15340,9 +15289,7 @@
                 "minimatch": "^3.0.4",
                 "natural-compare": "^1.4.0",
                 "optionator": "^0.9.1",
-                "progress": "^2.0.0",
                 "regexpp": "^3.2.0",
-                "semver": "^7.2.1",
                 "strip-ansi": "^6.0.1",
                 "strip-json-comments": "^3.1.0",
                 "text-table": "^0.2.0",
@@ -15354,7 +15301,6 @@
                     "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
                     "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
                     "dev": true,
-                    "peer": true,
                     "requires": {
                         "color-convert": "^2.0.1"
                     }
@@ -15364,7 +15310,6 @@
                     "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
                     "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
                     "dev": true,
-                    "peer": true,
                     "requires": {
                         "ansi-styles": "^4.1.0",
                         "supports-color": "^7.1.0"
@@ -15375,7 +15320,6 @@
                     "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
                     "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
                     "dev": true,
-                    "peer": true,
                     "requires": {
                         "color-name": "~1.1.4"
                     }
@@ -15384,22 +15328,19 @@
                     "version": "1.1.4",
                     "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
                     "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-                    "dev": true,
-                    "peer": true
+                    "dev": true
                 },
                 "escape-string-regexp": {
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
                     "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-                    "dev": true,
-                    "peer": true
+                    "dev": true
                 },
                 "eslint-scope": {
                     "version": "7.1.0",
                     "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.0.tgz",
                     "integrity": "sha512-aWwkhnS0qAXqNOgKOK0dJ2nvzEbhEvpy8OlJ9kZ0FeZnA6zpjv1/Vei+puGFFX7zkPCkHHXb7IDX3A+7yPrRWg==",
                     "dev": true,
-                    "peer": true,
                     "requires": {
                         "esrecurse": "^4.3.0",
                         "estraverse": "^5.2.0"
@@ -15409,15 +15350,13 @@
                     "version": "5.3.0",
                     "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
                     "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-                    "dev": true,
-                    "peer": true
+                    "dev": true
                 },
                 "glob-parent": {
                     "version": "6.0.2",
                     "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
                     "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
                     "dev": true,
-                    "peer": true,
                     "requires": {
                         "is-glob": "^4.0.3"
                     }
@@ -15427,7 +15366,6 @@
                     "resolved": "https://registry.npmjs.org/globals/-/globals-13.12.0.tgz",
                     "integrity": "sha512-uS8X6lSKN2JumVoXrbUz+uG4BYG+eiawqm3qFcT7ammfbUHeCBoJMlHcec/S3krSk73/AE/f0szYFmgAA3kYZg==",
                     "dev": true,
-                    "peer": true,
                     "requires": {
                         "type-fest": "^0.20.2"
                     }
@@ -15436,15 +15374,19 @@
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
                     "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-                    "dev": true,
-                    "peer": true
+                    "dev": true
+                },
+                "ignore": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
+                    "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+                    "dev": true
                 },
                 "supports-color": {
                     "version": "7.2.0",
                     "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
                     "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
                     "dev": true,
-                    "peer": true,
                     "requires": {
                         "has-flag": "^4.0.0"
                     }
@@ -15453,18 +15395,17 @@
                     "version": "0.20.2",
                     "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
                     "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-                    "dev": true,
-                    "peer": true
+                    "dev": true
                 }
             }
         },
         "eslint-config-next": {
-            "version": "12.0.7",
-            "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-12.0.7.tgz",
-            "integrity": "sha512-kWOaym5qjyzR190zFKkZMaHetmiRORmzJiKML7Kr9CL213S6SwkrHHCEL58TRdpx0NA+HzrsFR9zgcV2pvV2Yg==",
+            "version": "12.0.10",
+            "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-12.0.10.tgz",
+            "integrity": "sha512-l1er6mwSo1bltjLwmd71p5BdT6k/NQxV1n4lKZI6xt3MDMrq7ChUBr+EecxOry8GC/rCRUtPpH8Ygs0BJc5YLg==",
             "dev": true,
             "requires": {
-                "@next/eslint-plugin-next": "12.0.7",
+                "@next/eslint-plugin-next": "12.0.10",
                 "@rushstack/eslint-patch": "^1.0.8",
                 "@typescript-eslint/parser": "^5.0.0",
                 "eslint-import-resolver-node": "^0.3.4",
@@ -15692,7 +15633,6 @@
             "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
             "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
             "dev": true,
-            "peer": true,
             "requires": {
                 "eslint-visitor-keys": "^2.0.0"
             },
@@ -15701,15 +15641,14 @@
                     "version": "2.1.0",
                     "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
                     "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
-                    "dev": true,
-                    "peer": true
+                    "dev": true
                 }
             }
         },
         "eslint-visitor-keys": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.1.0.tgz",
-            "integrity": "sha512-yWJFpu4DtjsWKkt5GeNBBuZMlNcYVs6vRCLoCVEJrTjaSB6LC98gFipNK/erM2Heg/E8mIK+hXG/pJMLK+eRZA==",
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.2.0.tgz",
+            "integrity": "sha512-IOzT0X126zn7ALX0dwFiUQEdsfzrm4+ISsQS8nukaJXwEyYKRSnEIIDULYg1mCtGp7UUXgfGl7BIolXREQK+XQ==",
             "dev": true
         },
         "espree": {
@@ -15717,7 +15656,6 @@
             "resolved": "https://registry.npmjs.org/espree/-/espree-9.3.0.tgz",
             "integrity": "sha512-d/5nCsb0JcqsSEeQzFZ8DH1RmxPcglRWh24EFTlUEmCKoehXGdpsx0RkHDubqUI8LSAIKMQp4r9SzQ3n+sm4HQ==",
             "dev": true,
-            "peer": true,
             "requires": {
                 "acorn": "^8.7.0",
                 "acorn-jsx": "^5.3.1",
@@ -15728,8 +15666,7 @@
                     "version": "8.7.0",
                     "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
                     "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
-                    "dev": true,
-                    "peer": true
+                    "dev": true
                 }
             }
         },
@@ -15743,7 +15680,6 @@
             "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.4.0.tgz",
             "integrity": "sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==",
             "dev": true,
-            "peer": true,
             "requires": {
                 "estraverse": "^5.1.0"
             },
@@ -15752,8 +15688,7 @@
                     "version": "5.3.0",
                     "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
                     "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-                    "dev": true,
-                    "peer": true
+                    "dev": true
                 }
             }
         },
@@ -15761,7 +15696,6 @@
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
             "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
-            "peer": true,
             "requires": {
                 "estraverse": "^5.2.0"
             },
@@ -15769,8 +15703,7 @@
                 "estraverse": {
                     "version": "5.3.0",
                     "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-                    "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-                    "peer": true
+                    "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="
                 }
             }
         },
@@ -15904,7 +15837,6 @@
             "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
             "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
             "dev": true,
-            "peer": true,
             "requires": {
                 "flat-cache": "^3.0.4"
             }
@@ -15932,7 +15864,6 @@
             "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
             "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
             "dev": true,
-            "peer": true,
             "requires": {
                 "flatted": "^3.1.0",
                 "rimraf": "^3.0.2"
@@ -15942,8 +15873,7 @@
             "version": "3.2.4",
             "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.4.tgz",
             "integrity": "sha512-8/sOawo8tJ4QOBX8YlQBMxL8+RLZfxMQOif9o0KUKTNTjMYElWPE0r/m5VNFxTRd0NSw8qSy8dajrwX4RYI1Hw==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "follow-redirects": {
             "version": "1.14.7",
@@ -15997,8 +15927,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
             "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "gauge": {
             "version": "2.7.4",
@@ -16357,8 +16286,7 @@
             "version": "4.0.6",
             "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
             "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "immediate": {
             "version": "3.0.6",
@@ -16370,7 +16298,6 @@
             "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
             "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
             "dev": true,
-            "peer": true,
             "requires": {
                 "parent-module": "^1.0.0",
                 "resolve-from": "^4.0.0"
@@ -17934,7 +17861,6 @@
             "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
             "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
             "dev": true,
-            "peer": true,
             "requires": {
                 "argparse": "^2.0.1"
             }
@@ -18017,15 +17943,13 @@
         "json-schema-traverse": {
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-            "peer": true
+            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
         },
         "json-stable-stringify-without-jsonify": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
             "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "json5": {
             "version": "2.2.0",
@@ -18156,7 +18080,6 @@
             "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
             "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
             "dev": true,
-            "peer": true,
             "requires": {
                 "prelude-ls": "^1.2.1",
                 "type-check": "~0.4.0"
@@ -18177,9 +18100,9 @@
             "dev": true
         },
         "lint-staged": {
-            "version": "12.1.7",
-            "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-12.1.7.tgz",
-            "integrity": "sha512-bltv/ejiLWtowExpjU+s5z8j1Byjg9AlmaAjMmqNbIicY69u6sYIwXGg0dCn0TlkrrY2CphtHIXAkbZ+1VoWQQ==",
+            "version": "12.3.3",
+            "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-12.3.3.tgz",
+            "integrity": "sha512-OqcLsqcPOqzvsfkxjeBpZylgJ3SRG1RYqc9LxC6tkt6tNsq1bNVkAixBwX09f6CobcHswzqVOCBpFR1Fck0+ag==",
             "dev": true,
             "requires": {
                 "cli-truncate": "^3.1.0",
@@ -18188,10 +18111,10 @@
                 "debug": "^4.3.3",
                 "execa": "^5.1.1",
                 "lilconfig": "2.0.4",
-                "listr2": "^3.13.5",
+                "listr2": "^4.0.1",
                 "micromatch": "^4.0.4",
                 "normalize-path": "^3.0.0",
-                "object-inspect": "^1.11.1",
+                "object-inspect": "^1.12.0",
                 "string-argv": "^0.3.1",
                 "supports-color": "^9.2.1",
                 "yaml": "^1.10.2"
@@ -18212,9 +18135,9 @@
             }
         },
         "listr2": {
-            "version": "3.14.0",
-            "resolved": "https://registry.npmjs.org/listr2/-/listr2-3.14.0.tgz",
-            "integrity": "sha512-TyWI8G99GX9GjE54cJ+RrNMcIFBfwMPxc3XTFiAYGN4s10hWROGtOg7+O6u6LE3mNkyld7RSLE6nrKBvTfcs3g==",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/listr2/-/listr2-4.0.2.tgz",
+            "integrity": "sha512-YcgwfCWpvPbj9FLUGqvdFvd3hrFWKpOeuXznRgfWEJ7RNr8b/IKKIKZABHx3aU+4CWN/iSAFFSReziQG6vTeIA==",
             "dev": true,
             "requires": {
                 "cli-truncate": "^2.1.0",
@@ -18222,7 +18145,7 @@
                 "log-update": "^4.0.0",
                 "p-map": "^4.0.0",
                 "rfdc": "^1.3.0",
-                "rxjs": "^7.5.1",
+                "rxjs": "^7.5.2",
                 "through": "^2.3.8",
                 "wrap-ansi": "^7.0.0"
             },
@@ -18328,8 +18251,7 @@
             "version": "4.6.2",
             "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
             "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "log-update": {
             "version": "4.0.0",
@@ -18549,22 +18471,22 @@
             "peer": true
         },
         "next": {
-            "version": "12.0.9",
-            "resolved": "https://registry.npmjs.org/next/-/next-12.0.9.tgz",
-            "integrity": "sha512-omfYqoR/DvbdOIJ6SS1unKJ4mGIxUPs0RPa7wr/Mft22OCKgJhuG+aI9KFYi5ZJBwoFQk1vqaMKpWz5qr+dN0Q==",
+            "version": "12.0.10",
+            "resolved": "https://registry.npmjs.org/next/-/next-12.0.10.tgz",
+            "integrity": "sha512-1y3PpGzpb/EZzz1jgne+JfZXKAVJUjYXwxzrADf/LWN+8yi9o79vMLXpW3mevvCHkEF2sBnIdjzNn16TJrINUw==",
             "requires": {
-                "@next/env": "12.0.9",
-                "@next/swc-android-arm64": "12.0.9",
-                "@next/swc-darwin-arm64": "12.0.9",
-                "@next/swc-darwin-x64": "12.0.9",
-                "@next/swc-linux-arm-gnueabihf": "12.0.9",
-                "@next/swc-linux-arm64-gnu": "12.0.9",
-                "@next/swc-linux-arm64-musl": "12.0.9",
-                "@next/swc-linux-x64-gnu": "12.0.9",
-                "@next/swc-linux-x64-musl": "12.0.9",
-                "@next/swc-win32-arm64-msvc": "12.0.9",
-                "@next/swc-win32-ia32-msvc": "12.0.9",
-                "@next/swc-win32-x64-msvc": "12.0.9",
+                "@next/env": "12.0.10",
+                "@next/swc-android-arm64": "12.0.10",
+                "@next/swc-darwin-arm64": "12.0.10",
+                "@next/swc-darwin-x64": "12.0.10",
+                "@next/swc-linux-arm-gnueabihf": "12.0.10",
+                "@next/swc-linux-arm64-gnu": "12.0.10",
+                "@next/swc-linux-arm64-musl": "12.0.10",
+                "@next/swc-linux-x64-gnu": "12.0.10",
+                "@next/swc-linux-x64-musl": "12.0.10",
+                "@next/swc-win32-arm64-msvc": "12.0.10",
+                "@next/swc-win32-ia32-msvc": "12.0.10",
+                "@next/swc-win32-x64-msvc": "12.0.10",
                 "caniuse-lite": "^1.0.30001283",
                 "postcss": "8.4.5",
                 "styled-jsx": "5.0.0",
@@ -18741,7 +18663,6 @@
             "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
             "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
             "dev": true,
-            "peer": true,
             "requires": {
                 "deep-is": "^0.1.3",
                 "fast-levenshtein": "^2.0.6",
@@ -18804,7 +18725,6 @@
             "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
             "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
             "dev": true,
-            "peer": true,
             "requires": {
                 "callsites": "^3.0.0"
             }
@@ -18950,8 +18870,7 @@
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
             "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "prettier": {
             "version": "2.5.1",
@@ -19192,8 +19111,7 @@
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
             "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "require-directory": {
             "version": "2.1.1",
@@ -19237,8 +19155,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
             "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "resolve.exports": {
             "version": "1.1.0",
@@ -19628,8 +19545,7 @@
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
             "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "style-to-js": {
             "version": "1.1.0",
@@ -19814,8 +19730,7 @@
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
             "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "throat": {
             "version": "6.0.1",
@@ -19939,7 +19854,6 @@
             "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
             "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
             "dev": true,
-            "peer": true,
             "requires": {
                 "prelude-ls": "^1.2.1"
             }
@@ -19995,7 +19909,6 @@
             "version": "4.4.1",
             "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
             "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-            "peer": true,
             "requires": {
                 "punycode": "^2.1.0"
             }
@@ -20041,8 +19954,7 @@
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
             "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
-            "dev": true,
-            "peer": true
+            "dev": true
         },
         "v8-to-istanbul": {
             "version": "8.1.1",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
         "amplitude-js": "^8.8.0",
         "classnames": "^2.3.1",
         "html-react-parser": "^1.4.6",
-        "next": "^12.0.9",
+        "next": "^12.0.10",
         "next-sanity": "^0.4.0",
         "node-cache": "^5.1.2",
         "react": "^17.0.2",
@@ -40,15 +40,16 @@
         "@types/react": "^17.0.38",
         "@types/react-collapse": "^5.0.1",
         "@types/styled-components": "^5.1.19",
-        "eslint-config-next": "^12.0.7",
+        "eslint": "^8.8.0",
+        "eslint-config-next": "^12.0.10",
         "husky": "^7.0.4",
         "jest": "^27.4.7",
-        "lint-staged": "^12.1.7",
+        "lint-staged": "^12.3.3",
         "prettier": "^2.5.1",
         "typescript": "^4.5.4"
     },
     "lint-staged": {
         "*.{js,ts,tsx,less,css,md}": "prettier --write",
-        "*.{js,ts,tsx}": "next lint"
+        "*.{js,jsx,ts,tsx}": "eslint --fix"
     }
 }


### PR DESCRIPTION
Det hender at lint-staged tryner på `next lint` lokalt. Bruker `eslint --fix` enn så lenge. Oppgraderer samtidig nextjs og relaterte pakker til linting.